### PR TITLE
Add MSVC build capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.17)
+
+project(moonchipmunk)
+
+find_package(Lua REQUIRED)
+
+#needs to be manually created until chipmunk provides a chipmunkConfig.cmake
+find_package(chipmunk REQUIRED)
+
+add_library(moonchipmunk SHARED
+	src/compat-5.3.h
+	src/constraint.h
+	src/enums.h
+	src/internal.h
+	src/moonchipmunk.h
+	src/objects.h
+	src/tree.h
+	src/udata.h
+	src/arbiter.c
+	src/body.c
+	src/circle.c
+	src/collision_handler.c
+	src/compat-5.3.c
+	src/constraint.c
+	src/damped_rotary_spring.c
+	src/damped_spring.c
+	src/datastructs.c
+	src/enums.c
+	src/flags.c
+	src/gear_joint.c
+	src/groove_joint.c
+	src/main.c
+	src/misc.c
+	src/objects.c
+	src/pin_joint.c
+	src/pivot_joint.c
+	src/poly.c
+	src/ratchet_joint.c
+	src/rotary_limit_joint.c
+	src/segment.c
+	src/shape.c
+	src/simple_motor.c
+	src/slide_joint.c
+	src/space.c
+	src/tracing.c
+	src/udata.c
+	src/utils.c
+)
+
+target_include_directories(moonchipmunk PUBLIC
+	${LUA_INCLUDE_DIR}
+	${chipmunk_INCLUDE_DIR}
+)
+
+target_link_libraries(moonchipmunk
+	${LUA_LIBRARIES}
+	${chipmunk_LIBS}
+)
+
+install(TARGETS moonchipmunk LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS moonchipmunk RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/internal.h
+++ b/src/internal.h
@@ -49,6 +49,12 @@
 #define  moonchipmunk_
 #endif
 
+#ifdef _WIN32
+    #define MOONCHIPMUNK_EXPORT __declspec(dllexport)
+#else
+    #define MOONCHIPMUNK_EXPORT
+#endif
+
 /* flags.c */
 #define checkflags(L, arg) luaL_checkinteger((L), (arg))
 #define optflags(L, arg, defval) luaL_optinteger((L), (arg), (defval))
@@ -215,7 +221,7 @@ int newbody(lua_State *L, body_t *body, int borrowed);
 
 /* main.c */
 extern lua_State *moonchipmunk_L;
-int luaopen_moonchipmunk(lua_State *L);
+MOONCHIPMUNK_EXPORT int luaopen_moonchipmunk(lua_State *L);
 void moonchipmunk_open_enums(lua_State *L);
 void moonchipmunk_open_flags(lua_State *L);
 void moonchipmunk_open_tracing(lua_State *L);

--- a/src/tree.h
+++ b/src/tree.h
@@ -375,8 +375,15 @@ struct {                                \
 /* Generates prototypes and inline functions */
 #define RB_PROTOTYPE(name, type, field, cmp)                \
     RB_PROTOTYPE_INTERNAL(name, type, field, cmp,)
-#define RB_PROTOTYPE_STATIC(name, type, field, cmp)         \
-    RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+
+#ifdef _MSC_VER
+    #define RB_PROTOTYPE_STATIC(name, type, field, cmp)         \
+        RB_PROTOTYPE_INTERNAL(name, type, field, cmp, static)
+#else
+    #define RB_PROTOTYPE_STATIC(name, type, field, cmp)         \
+        RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+#endif
+
 #define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)     \
 attr void name##_RB_INSERT_COLOR(struct name *, struct type *);     \
 attr void name##_RB_REMOVE_COLOR(struct name *, struct type *, struct type *);\
@@ -394,8 +401,15 @@ attr struct type *name##_RB_MINMAX(struct name *, int);         \
  */
 #define RB_GENERATE(name, type, field, cmp)             \
     RB_GENERATE_INTERNAL(name, type, field, cmp,)
-#define RB_GENERATE_STATIC(name, type, field, cmp)          \
-    RB_GENERATE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+
+#ifdef _MSC_VER
+    #define RB_GENERATE_STATIC(name, type, field, cmp)          \
+        RB_GENERATE_INTERNAL(name, type, field, cmp, static)
+#else
+    #define RB_GENERATE_STATIC(name, type, field, cmp)          \
+        RB_GENERATE_INTERNAL(name, type, field, cmp, __attribute__((__unused__)) static)
+#endif
+
 #define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)      \
 attr void                               \
 name##_RB_INSERT_COLOR(struct name *head, struct type *elm)     \

--- a/src/utils.c
+++ b/src/utils.c
@@ -164,7 +164,7 @@ void sleeep(double seconds)
 
 #define time_init(L) do { (void)L; /* do nothing */ } while(0)
 
-#elif defined(MINGW)
+#elif defined(_WIN32)
 
 #include <windows.h>
 


### PR DESCRIPTION
This PR adds the ability to build with MSVC. I do not believe this will impact existing build targets. 
MinGW also defines _WIN32
_MSC_VER is not defined by MinGW

I added my CMakeLists.txt for convenience but can be dropped if is not desirable.

This expands on the build options available as discussed in #1