### PR TITLE
add body get_user_data and set_user_data functions

### DIFF
--- a/src/body.c
+++ b/src/body.c
@@ -34,6 +34,7 @@ static void removeshape(body_t *body, shape_t *shape, void *data)
 int freebody(lua_State *L, ud_t *ud)
     {
     space_t *space;
+	cpDataPointer *ref;
     body_t *body = (body_t*)ud->handle;
     if(!IsValid(ud)) return 0;
     space = cpBodyGetSpace(body);
@@ -51,6 +52,8 @@ int freebody(lua_State *L, ud_t *ud)
             cpBodyEachShape(body, removeshape, space);
             cpSpaceRemoveBody(space, body);
             }
+        ref = cpBodyGetUserData(body);
+        if(ref) luaL_unref(L, LUA_REGISTRYINDEX, (lua_Integer)ref);
         cpBodyFree(body);
         }
     return 0;
@@ -375,6 +378,8 @@ static int SetUserData(lua_State *L)
     intptr_t ref;
     body_t *body = checkbody(L, 1, NULL);
     luaL_checktype(L, 2, LUA_TTABLE);
+    ref = (intptr_t)cpBodyGetUserData(body);
+    if(ref) luaL_unref(L, LUA_REGISTRYINDEX, (lua_Integer)ref);
     ref = luaL_ref(L, LUA_REGISTRYINDEX);
     cpBodySetUserData(body, (cpDataPointer*)ref);
     return 0;
@@ -383,9 +388,9 @@ static int SetUserData(lua_State *L)
 static int GetUserData(lua_State *L)
     {
     body_t *body = checkbody(L, 1, NULL);
-    cpDataPointer * ptr = cpBodyGetUserData(body);
-    if(!ptr) lua_pushnil(L);
-    else lua_rawgeti(L, LUA_REGISTRYINDEX, (lua_Integer)ptr);
+    cpDataPointer *ref = cpBodyGetUserData(body);
+    if(!ref) lua_pushnil(L);
+    else lua_rawgeti(L, LUA_REGISTRYINDEX, (lua_Integer)ref);
     return 1;
     }
 

--- a/src/body.c
+++ b/src/body.c
@@ -370,6 +370,25 @@ static int SetPositionUpdateFunc(lua_State *L)
     return 0;
     }
 
+static int SetUserData(lua_State *L)
+    {
+    intptr_t ref;
+    body_t *body = checkbody(L, 1, NULL);
+    luaL_checktype(L, 2, LUA_TTABLE);
+    ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    cpBodySetUserData(body, (cpDataPointer*)ref);
+    return 0;
+    }
+
+static int GetUserData(lua_State *L)
+    {
+    body_t *body = checkbody(L, 1, NULL);
+    cpDataPointer * ptr = cpBodyGetUserData(body);
+    if(!ptr) lua_pushnil(L);
+    else lua_rawgeti(L, LUA_REGISTRYINDEX, (lua_Integer)ptr);
+    return 1;
+    }
+
 RAW_FUNC(body)
 PARENT_FUNC(body)
 DESTROY_FUNC(body)
@@ -423,6 +442,8 @@ static const struct luaL_Reg Methods[] =
         { "each_arbiter", EachArbiter },
         { "set_velocity_update_func", SetVelocityUpdateFunc },
         { "set_position_update_func", SetPositionUpdateFunc },
+        { "set_user_data", SetUserData },
+        { "get_user_data", GetUserData },
         { NULL, NULL } /* sentinel */
     };
 
@@ -445,8 +466,3 @@ void moonchipmunk_open_body(lua_State *L)
     udata_define(L, BODY_MT, Methods, MetaMethods);
     luaL_setfuncs(L, Functions, 0);
     }
-
-#if 0
-// void cpBodySetUserData(body_t *body, cpDataPointer userData);
-// cpDataPointer cpBodyGetUserData(const body_t *body);
-#endif


### PR DESCRIPTION
Add get_user_data() and set_user_data() functions to body. This will retrieve/store a table reference using cpBodyGetUserData and cpBodySetUserData. Solves #3 . I wasn't sure how to update the documentation but it would be something like:
body:set_user_data(user_data_table)
user_data_table= body:get_user_data( )